### PR TITLE
Version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM alpine:latest
 MAINTAINER Arun Neelicattu <arun.neelicattu@gmail.com>
 
-ARG OXIDISED_VERSION=0.19.0
-ARG OXIDISED_WEB_VERSION=0.8.0
+ARG OXIDISED_VERSION=0.29.1
+ARG OXIDISED_WEB_VERSION=0.13.0
 
 RUN apk --no-cache add --virtual oxidized-runtime \
         ruby git libssh2 sqlite-libs libressl \
-    && apk --no-cache add --virtual oxidized-build-deps \
+    && apk --no-cache add --virtual oxidized-build-deps icu-dev \
         ruby-dev cmake make libssh2-dev g++ sqlite-dev libressl-dev \
     && gem install \
-         --no-ri --no-rdoc \
+         --no-document \
         json aws-sdk slack-api \
         oxidized:${OXIDISED_VERSION} oxidized-web:${OXIDISED_WEB_VERSION} \
     && apk --no-cache del oxidized-build-deps


### PR DESCRIPTION
Update the versions and include icu-dev which is needed by oxidized-web gem to build